### PR TITLE
Update plot.py

### DIFF
--- a/gseapy/plot.py
+++ b/gseapy/plot.py
@@ -431,7 +431,7 @@ def dotplot(df, column='Adjusted P-value', title='', cutoff=0.05, top_term=10,
         idx = [area.argmax(), np.abs(area - area.mean()).argmin(), area.argmin()]
         idx = unique(idx)
     else:
-        idx = df.index.values
+        idx = range(len(df))
     label = df.iloc[idx, df.columns.get_loc('Hits')]
     
     if legend:


### PR DESCRIPTION
for certain enrichments, 
https://github.com/zqfang/GSEApy/blob/b6f2a334dba32dc31f4255e3e853fcdaea2e36be/gseapy/plot.py#L435 throws an index is out of range error. I believe the issue is the assignment in https://github.com/zqfang/GSEApy/blob/b6f2a334dba32dc31f4255e3e853fcdaea2e36be/gseapy/plot.py#L434 , which yields a set of index values that are then passed to `iloc`, which expects positional indices, **not** dataframe indices. This leads to incorrect results/errors when ordering according to p-value (df.index) does not agree with ordering according to adjusted p-values.

This can be corrected by assigning `range(len(df))` instead of `df.index.values` to `idx`