### PR TITLE
Parallelism fix to reduce errors on large datasets like scRNAseq

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ matplotlib>=1.4.3
 pandas>=0.16
 beautifulsoup4>=4.4.1
 requests
-
+joblib

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandas>=0.16
 beautifulsoup4>=4.4.1
 requests
 joblib
+bioservices>=1.7.3


### PR DESCRIPTION
This fix circumvents pickling errors generated by `gseapy/algorithm.py` line 374, which large datasets (e.g. scRNAseq) are particularly vulnerable to. The gsea tensor computation can generate blocks which are larger than 4 GB, which do not fit in the `i` struct formatter used by python's build in multiprocessing module.