### PR TITLE
Fix t-test always returns 1e9 FDR

### DIFF
--- a/gseapy/algorithm.py
+++ b/gseapy/algorithm.py
@@ -370,8 +370,10 @@ def ranking_metric(df, method, pos, neg, classes, ascending):
     # exclude any zero stds.
     df_mean = df.groupby(by=classes, axis=1).mean()
     df_std = df.groupby(by=classes, axis=1).std()
-    n_pos = np.sum(classes == pos)
-    n_neg = np.sum(classes == neg)
+    class_values = np.array(list(classes.values()))
+    n_pos = np.sum(class_values == pos)
+    n_neg = np.sum(class_values == neg)
+
     if method in ["signal_to_noise", "s2n"]:
         ser = (df_mean[pos] - df_mean[neg]) / (df_std[pos] + df_std[neg])
     elif method in ["abs_signal_to_noise", "abs_s2n"]:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -50,7 +50,7 @@ def test_gsea(gseaGCT, gseaCLS, geneGMT):
     # Only tests of the command runs successfully,
     # doesnt't check the image
     tmpdir = TemporaryDirectory(dir="tests")
-    gsea(
+    gs_res = gsea(
         data=gseaGCT,
         gene_sets=geneGMT,
         cls=gseaCLS,
@@ -61,6 +61,22 @@ def test_gsea(gseaGCT, gseaCLS, geneGMT):
     )
     tmpdir.cleanup()
 
+def test_fdr_gsea(gseaGCT, gseaCLS, geneGMT):
+    # Runs and verifies a reasonable result for pval
+    # when method="t_test" and permutation_type="gene_set"
+    tmpdir = TemporaryDirectory(dir="tests")
+    gs_res = gsea(
+        data=gseaGCT,
+        gene_sets=geneGMT,
+        cls=gseaCLS,
+        method="t_test",
+        outdir=tmpdir.name,
+        permutation_type="gene_set",
+        permutation_num=47,
+        seed=7,
+    )
+    assert gs_res.res2d['pval'].max() > 0.0
+    tmpdir.cleanup()
 
 def test_prerank(prernk, geneGMT):
     # Only tests of the command runs successfully,


### PR DESCRIPTION
Bug: Running `gp.gsea( ... , method='t_test',)` with cls as a python list returns unusable result.

Existing code always sets `n_pos`, `n_neg` to 0.

For example:
```
pos = 'FHL'
classes = {'FHL3': 'FHL', 'FHL2': 'FHL', 'FHL1': 'FHL', 'FHL6': 'FHL', 
'FHL5': 
'FHL', 'FHL7': 'FHL', 'FHL4': 'FHL', 'CTL4': 'CTL', 'CTL7': 'CTL', 'CTL5': 
'CTL', 'CTL6': 'CTL', 'CTL3': 'CTL', 'CTL2': 'CTL', 'CTL1': 'CTL'}
np.sum(classes == pos) # returns 0
classes == pos # returns False
```

I'm not sure if this worked in an easier version of python, but using 3.9 
comparing a dict to string returns False.  

This is not a problem in `ranking_metric_tensor` because you compare using an np.array 
[ref](https://github.com/zqfang/GSEApy/blob/master/gseapy/algorithm.py#L286-L290), but `ranking_metric` takes a dict for classes so it needs to be converted to an array of just the values before you can compare with the class.

Thanks
