### PR TITLE
fix: throw error for empty gene lists in enrich

### DIFF
--- a/gseapy/enrichr.py
+++ b/gseapy/enrichr.py
@@ -186,6 +186,9 @@ class Enrichr(object):
                 for gene in f:
                     genes.append(gene.strip())
 
+        if not genes:
+            raise ValueError("Gene list cannot be empty")
+
         self._isezid = all(map(self._is_entrez_id, genes))
         if self._isezid:
             self._gls = set(map(int, genes))


### PR DESCRIPTION
The case for gene list being empty is not handled in enrich, and since all([])  returns true, the code assumes that entrez_ids are being used, which convolutes the user.