### PR TITLE
Only check_uppercase for string genes

### DIFF
--- a/gseapy/enrichr.py
+++ b/gseapy/enrichr.py
@@ -609,7 +609,9 @@ class Enrichr(object):
 
         # read input file
         genes_list = self.parse_genelists()  #
-        self._gene_isupper = self.check_uppercase(self._gls)
+
+        if not self._isezid:
+            self._gene_isupper = self.check_uppercase(self._gls)
 
         # self._logger.info("Connecting to Enrichr Server to get latest library names")
         gss = self.parse_genesets()


### PR DESCRIPTION
This fixes a bug where `parse_genelists` converts the gene list into a set of ints which then throws an exception when calling isupper() on an int


```
/usr/local/lib/python3.11/dist-packages/gseapy/__init__.py:554: in enrichr
    enr.run()
/usr/local/lib/python3.11/dist-packages/gseapy/enrichr.py:612: in run
    self._gene_isupper = self.check_uppercase(self._gls)
/usr/local/lib/python3.11/dist-packages/gseapy/enrichr.py:266: in check_uppercase
    is_upper = [s.isupper() for s in gene_list]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <set_iterator object at 0x7fe68eac7300>

>   is_upper = [s.isupper() for s in gene_list]
E   AttributeError: 'int' object has no attribute 'isupper'
```