### PR TITLE
Fix fgsea multilevel p-values: apply denomProb normalisation and estimator selection

### DIFF
--- a/src/fgsea/mod.rs
+++ b/src/fgsea/mod.rs
@@ -76,8 +76,22 @@ pub fn scale_ranks(ranks: &[f64]) -> Vec<i64> {
 /// * `seed` — random seed.
 /// * `eps` — convergence threshold (fgsea default 1e-50; 0 disables early exit).
 ///
-/// Returns `(p_value, log2err)`. Sign handling, abs of ranks, and positive/negative
-/// ruler selection all happen inside `fgseaMultilevelCpp`.
+/// Returns `(conditional_p_value, is_cp_ge_half, log2err)`. Sign handling, abs of ranks,
+/// and positive/negative ruler selection all happen inside `fgseaMultilevelCpp`.
+///
+/// **The returned p-value is conditional** on the null ES sharing the sign of
+/// `observed_es`. It is fgsea's raw `cppMPval`, not a usable p-value on its own. The
+/// caller must divide it by `denomProb = (modeFraction + 1) / (nPermSimple + 1)`, the
+/// same-sign fraction of the simple-permutation null, exactly as `fgseaMultilevel` does:
+///
+/// ```r
+/// result[, pval := pmin(1, cpp.res$cppMPval / denomProb)]
+/// ```
+///
+/// `is_cp_ge_half` is fgsea's `cppIsCpGeHalf`; when false the p-value was likely
+/// overestimated and fgsea reports `log2err` as NA. The returned `log2err` is the core's
+/// own estimate for the *uncorrected* value; fgsea recomputes it from the corrected
+/// p-value via `multilevelError`, so callers should generally ignore it.
 pub fn compute_pvalue_multilevel(
     int_ranks: &[i64],
     pathway_size: usize,
@@ -85,9 +99,9 @@ pub fn compute_pvalue_multilevel(
     sample_size: usize,
     seed: u64,
     eps: f64,
-) -> (f64, f64) {
+) -> (f64, bool, f64) {
     if observed_es.abs() < 1e-15 || pathway_size == 0 || pathway_size >= int_ranks.len() {
-        return (1.0, f64::NAN);
+        return (1.0, true, f64::NAN);
     }
 
     // Scaled ranks sum to <= 1<<30, so every element fits in i32; fgseaMultilevelCpp
@@ -106,5 +120,5 @@ pub fn compute_pvalue_multilevel(
         false, // logStatus
     );
 
-    (res.cppMPval[0], res.log2err[0])
+    (res.cppMPval[0], res.cppIsCpGeHalf[0], res.log2err[0])
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,13 +1,65 @@
 #![allow(dead_code, unused)]
 
 use crate::algorithm::{EnrichmentScore, EnrichmentScoreTrait};
+use crate::fgsea::util::multilevelError;
 use crate::fgsea::{calcGseaStatCumulativeBatch, compute_pvalue_multilevel, scale_ranks};
 use crate::utils::{CorrelType, DynamicEnum, Metric, Statistic};
 use itertools::{izip, Itertools};
 use pyo3::prelude::*;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use special::Gamma;
+use statrs::function::beta::beta_reg;
 use std::collections::HashMap;
+
+/// The `p`-quantile of a Beta(`a`, `b`) distribution -- R's `qbeta(p, a, b)`.
+///
+/// Found by bisection on the regularised incomplete beta function (Beta's CDF),
+/// which is monotone on `[0, 1]`. 200 iterations take the bracket well below f64
+/// resolution. Degenerate shapes match R's boundary conventions: `qbeta` is 0 when
+/// `a <= 0` and 1 when `b <= 0`.
+fn qbeta(p: f64, a: f64, b: f64) -> f64 {
+    if a <= 0.0 {
+        return 0.0;
+    }
+    if b <= 0.0 {
+        return 1.0;
+    }
+    let (mut lo, mut hi) = (0.0f64, 1.0f64);
+    for _ in 0..200 {
+        let mid = 0.5 * (lo + hi);
+        if beta_reg(a, b, mid) < p {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    0.5 * (lo + hi)
+}
+
+/// Half-width (in log2 units) of the 95% interval around the simple permutation
+/// p-value estimate `(n_more_extreme + 1) / (n_perm + 1)`.
+///
+/// Mirrors the `leftBorder`/`rightBorder`/`crudeEstimator` block of `fgseaMultilevel`.
+/// With `n_more_extreme == 0` the left border is `log2(0) = -inf`, so the error is
+/// infinite and the multilevel estimator always wins -- which is the intent: zero
+/// more-extreme permutations tells you nothing about how small the p-value is.
+fn simple_error_log2(n_more_extreme: f64, n_perm: f64) -> f64 {
+    let left_border = qbeta(0.025, n_more_extreme, n_perm - n_more_extreme + 1.0).log2();
+    let right_border = qbeta(0.975, n_more_extreme + 1.0, n_perm - n_more_extreme).log2();
+    let crude = ((n_more_extreme + 1.0) / (n_perm + 1.0)).log2();
+    0.5 * (crude - left_border).max(right_border - crude)
+}
+
+/// Expected log2 error of the multilevel estimate of `pval` -- fgsea's
+/// `multilevelError(pval, sampleSize)`.
+///
+/// The multilevel algorithm needs `floor(-log2(pval) + 1)` splitting levels to reach
+/// `pval`, and each level contributes independent sampling error.
+fn multilevel_error_pval(pval: f64, sample_size: usize) -> f64 {
+    let level = (-pval.log2() + 1.0).floor();
+    multilevelError(level as i32, sample_size as i32)
+}
 
 #[pyclass(from_py_object)]
 #[allow(dead_code)]
@@ -975,29 +1027,25 @@ impl GSEAResult {
             let observed_es = es.fast_random_walk(&weighted_metric, &gtag);
             let run_es = es.running_enrichment_score(&weighted_metric, &gtag);
 
-            // Multilevel p-value and log2 error bound (faithful fgsea core).
-            let (ml_pval, ml_log2err) = compute_pvalue_multilevel(
-                &int_ranks,
-                gidx.len(),
-                observed_es,
-                sample_size,
-                self.seed,
-                eps,
-            );
-
+            // p-value is deferred: fgsea needs the simple-permutation null (computed in
+            // one batch below) both to normalise the multilevel estimate and to decide
+            // which estimator to use for each gene set.
             pathway_sizes.push(gidx.len() as i32);
             pathway_scores.push(observed_es);
             summ.push(GSEASummary {
                 term: term.to_string(),
                 es: observed_es,
-                pval: ml_pval,
-                log2err: ml_log2err,
+                pval: f64::NAN,
+                log2err: f64::NAN,
                 fwerp: 1.0,
                 run_es,
                 hits: gidx,
                 ..Default::default()
             });
         }
+
+        let mut n_unbalanced = 0usize;
+        let mut n_overestimated = 0usize;
 
         // NES via fgsea's random-gene-set null (calcGseaStatCumulativeBatch):
         // for each of `nperm` random size-k samples, the per-size prefix ES is
@@ -1027,29 +1075,138 @@ impl GSEAResult {
                 } else {
                     0.0
                 };
-                s.nes = if s.es >= 0.0 {
-                    if ge_mean != 0.0 {
-                        s.es / ge_mean
-                    } else {
-                        s.es
-                    }
-                } else if le_mean != 0.0 {
-                    s.es / le_mean.abs()
+                // NES is normalised by the mean null ES of the SAME sign. `ES > 0`
+                // (not `>= 0`) matches fgseaSimpleImpl, which sends a zero ES to the
+                // negative branch.
+                let nes_mean = if s.es > 0.0 { ge_mean } else { le_mean.abs() };
+                s.nes = if nes_mean != 0.0 { s.es / nes_mean } else { f64::NAN };
+
+                // ---- p-value, following fgseaMultilevel's two-estimator scheme ----
+                //
+                // `modeFraction` counts the permutations whose null ES has the same
+                // sign as the observed ES; `nMoreExtreme` counts those at least as
+                // extreme as it. (fgsea uses `ES >= 0` for the former and `ES > 0` for
+                // the latter; both are reproduced verbatim.)
+                let n_perm = self.nperm as f64;
+                let mode_fraction = if s.es >= 0.0 {
+                    batch.geZero[j]
                 } else {
-                    s.es
+                    batch.leZero[j]
                 };
+                let n_more_extreme = if s.es > 0.0 {
+                    batch.geEs[j]
+                } else {
+                    batch.leEs[j]
+                };
+
+                // No same-sign null mass to normalise against, or too little of it:
+                // fgsea reports pval/NES/log2err as NA rather than a number it cannot
+                // stand behind.
+                if s.nes.is_nan() || mode_fraction < 10.0 {
+                    n_unbalanced += 1;
+                    s.pval = f64::NAN;
+                    s.nes = f64::NAN;
+                    s.log2err = f64::NAN;
+                    continue;
+                }
+
+                // fgsea compares the two estimators' accuracy on the crude estimate
+                // (nMoreExtreme + 1) / (nPerm + 1), not on the reported p-value.
+                let crude = (n_more_extreme + 1.0) / (n_perm + 1.0);
+                let simple_err = simple_error_log2(n_more_extreme, n_perm);
+                let mult_err = multilevel_error_pval(crude, sample_size);
+
+                if mult_err >= simple_err {
+                    // The simple permutation estimate is at least as accurate here as
+                    // the multilevel one would be, so fgsea keeps it. This is the
+                    // common case: for all but the smallest p-values, `nperm` draws
+                    // resolve the tail better than multilevel sampling does.
+                    //
+                    // Each side is normalised by its OWN sign's null count, and the
+                    // smaller of the two is taken -- normalising by `n_perm` instead
+                    // would bias every p-value low by the same-sign fraction (~2x).
+                    s.pval = ((1.0 + batch.leEs[j]) / (1.0 + batch.leZero[j]))
+                        .min((1.0 + batch.geEs[j]) / (1.0 + batch.geZero[j]));
+                    s.log2err = ((n_more_extreme + 1.0).trigamma() - (n_perm + 1.0).trigamma())
+                        .sqrt()
+                        / std::f64::consts::LN_2;
+                } else {
+                    // Deep tail: fall back to adaptive multilevel splitting, which can
+                    // resolve p-values far below 1/nperm.
+                    let (cond_pval, is_cp_ge_half, _) = compute_pvalue_multilevel(
+                        &int_ranks,
+                        s.hits.len(),
+                        s.es,
+                        sample_size,
+                        self.seed,
+                        eps,
+                    );
+                    // The multilevel core returns a probability CONDITIONAL on the null
+                    // ES sharing the observed sign. Dividing by that sign's frequency
+                    // recovers the unconditional p-value; without this the result is
+                    // biased low by ~1/denom_prob (roughly 2x for a balanced metric).
+                    let denom_prob = (mode_fraction + 1.0) / (n_perm + 1.0);
+                    s.pval = (cond_pval / denom_prob).min(1.0);
+                    s.log2err = if is_cp_ge_half {
+                        multilevel_error_pval(s.pval, sample_size)
+                    } else {
+                        // p-value likely overestimated; fgsea declines to report an error bound.
+                        n_overestimated += 1;
+                        f64::NAN
+                    };
+                }
+
+                if s.pval < eps {
+                    s.pval = eps;
+                    s.log2err = f64::NAN;
+                }
             }
         } else {
+            // No simple-permutation null requested. Without it there is no
+            // `denomProb` to normalise the multilevel estimate against, so fall back
+            // to the raw conditional p-value and an unnormalised NES.
             for s in summ.iter_mut() {
-                s.nes = s.es; // no simple-permutation null requested (nperm == 0)
+                s.nes = s.es;
+                let (cond_pval, _, ml_log2err) = compute_pvalue_multilevel(
+                    &int_ranks,
+                    s.hits.len(),
+                    s.es,
+                    sample_size,
+                    self.seed,
+                    eps,
+                );
+                s.pval = cond_pval;
+                s.log2err = ml_log2err;
             }
         }
 
-        // Apply Benjamini-Hochberg correction across all gene sets for FDR.
-        let pvals: Vec<f64> = summ.iter().map(|s| s.pval).collect();
+        if n_unbalanced > 0 {
+            eprintln!(
+                "Warning: {} gene sets had fewer than 10 same-sign null enrichment scores \
+                 (unbalanced gene-level statistics); their pval, FDR, NES and log2err are NaN. \
+                 Increasing the number of permutations may help.",
+                n_unbalanced
+            );
+        }
+        if n_overestimated > 0 {
+            eprintln!(
+                "Warning: for {} gene sets the p-value was likely overestimated; \
+                 log2err is set to NaN.",
+                n_overestimated
+            );
+        }
+
+        // Benjamini-Hochberg correction for FDR. Gene sets with a NaN p-value are
+        // excluded from the correction (and keep a NaN FDR), matching p.adjust's
+        // handling of NAs -- leaving them in would corrupt the rank ordering.
+        let scored: Vec<usize> = (0..summ.len()).filter(|&i| !summ[i].pval.is_nan()).collect();
+        let pvals: Vec<f64> = scored.iter().map(|&i| summ[i].pval).collect();
         let fdrs = Self::bh_correction(&pvals);
-        for (s, fdr) in summ.iter_mut().zip(fdrs.iter()) {
-            s.fdr = *fdr;
+        for s in summ.iter_mut() {
+            s.fdr = f64::NAN;
+        }
+        for (&i, &fdr) in scored.iter().zip(fdrs.iter()) {
+            summ[i].fdr = fdr;
         }
 
         self.summaries = summ;
@@ -1333,6 +1490,101 @@ mod tests {
         for s in &gsea0.summaries {
             assert!((s.nes - s.es).abs() < EPSILON, "with n_perm_simple=0, nes should equal es");
         }
+    }
+
+    /// Load the bundled prerank fixtures, ready for `prerank_multilevel`.
+    ///
+    /// The metric keeps its SIGN and is sorted descending, which is what
+    /// `prerank_multilevel` expects -- it applies `|x|^weight` internally for the
+    /// enrichment score and needs the signed values for the permutation null. Passing
+    /// a pre-`abs()`ed metric makes every null enrichment score one-signed, which
+    /// drives `denomProb` to 1 and hides any error in the sign normalisation.
+    fn load_prerank_fixture() -> (Vec<String>, Vec<f64>, FileReader, FileReader) {
+        let cwd = std::env::current_dir().unwrap();
+        let mut rnk = FileReader::new();
+        let _ = rnk.read_csv(
+            cwd.join("tests/data/mds.2k.rnk").to_str().unwrap(), b'\t', false, Some(b'#'));
+        let mut gmt = FileReader::new();
+        let _ = gmt.read_table(
+            cwd.join("tests/data/c2.cp.kegg.v7.5.1.symbols.gmt").to_str().unwrap(), '\t', false);
+        let mut gene: Vec<String> = Vec::new();
+        let mut gene_metric: Vec<f64> = Vec::new();
+        for r in rnk.record.iter() {
+            gene.push(r[0].clone());
+            gene_metric.push(r[1].parse::<f64>().unwrap());
+        }
+        let (gidx, metric) = gene_metric.as_slice().argsort(false);
+        let gene = gidx.iter().map(|&i| gene[i].clone()).collect();
+        (gene, metric, rnk, gmt)
+    }
+
+    /// Under the null, p-values must be approximately Uniform(0, 1).
+    ///
+    /// This is the property that a missing `denomProb` normalisation destroys. The
+    /// multilevel core returns a probability CONDITIONAL on the null ES sharing the
+    /// observed ES's sign; reporting it directly makes every p-value roughly
+    /// `1 / denomProb` (~2x) too small. Shuffling the gene labels removes any real
+    /// enrichment, so a correctly normalised implementation gives mean(p) ~ 0.5 and
+    /// P(p < 0.05) ~ 0.05, while the unnormalised one gives ~0.29 and ~0.12.
+    #[test]
+    fn test_prerank_multilevel_null_calibration() {
+        let weight = 1.0;
+        let (gene, metric, _rnk, gmt) = load_prerank_fixture();
+        let mut gmt2 = HashMap::<&str, &[String]>::new();
+        gmt.record.iter().for_each(|r| { gmt2.insert(r[0].as_str(), &r[2..]); });
+
+        // Deterministic label shuffle (LCG): keeps the metric distribution intact but
+        // destroys any association between gene sets and the ranking.
+        let mut shuffled = gene.clone();
+        let mut state: u64 = 0x2545F491_4F6CDD1D;
+        for i in (1..shuffled.len()).rev() {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            shuffled.swap(i, (state >> 33) as usize % (i + 1));
+        }
+
+        let mut gsea = GSEAResult::new(weight, 500, 15, 1000, 42);
+        gsea.prerank_multilevel(&shuffled, &metric, &gmt2, 101, 1e-50);
+        let p: Vec<f64> = gsea.summaries.iter().map(|s| s.pval).filter(|v| !v.is_nan()).collect();
+        assert!(p.len() > 50, "expected a decent number of gene sets, got {}", p.len());
+
+        let mean = p.iter().sum::<f64>() / p.len() as f64;
+        let frac_sig = p.iter().filter(|&&v| v < 0.05).count() as f64 / p.len() as f64;
+        println!("null calibration: n={} mean(p)={:.4} P(p<0.05)={:.4}", p.len(), mean, frac_sig);
+
+        // Generous bounds: these must catch a ~2x bias, not police Monte-Carlo noise.
+        // The unnormalised implementation lands at mean ~0.29 / P ~0.12.
+        assert!((0.42..=0.58).contains(&mean),
+                "null p-values are not uniform: mean(p)={:.4}, expected ~0.5. \
+                 A low mean indicates the conditional multilevel p-value is not being \
+                 divided by denomProb.", mean);
+        assert!(frac_sig < 0.10,
+                "type-I error inflated: P(p<0.05)={:.4}, expected ~0.05", frac_sig);
+    }
+
+    /// `eps` floors the reported p-value, and fgsea reports no error bound once the
+    /// floor is hit (`result[pval < eps, c("pval","log2err") := list(eps, NA)]`).
+    #[test]
+    fn test_prerank_multilevel_eps_floor() {
+        let weight = 1.0;
+        let (gene, metric, _rnk, gmt) = load_prerank_fixture();
+        let mut gmt2 = HashMap::<&str, &[String]>::new();
+        gmt.record.iter().for_each(|r| { gmt2.insert(r[0].as_str(), &r[2..]); });
+
+        let eps = 1e-3;
+        let mut gsea = GSEAResult::new(weight, 500, 15, 1000, 42);
+        gsea.prerank_multilevel(&gene, &metric, &gmt2, 101, eps);
+
+        let mut clamped = 0;
+        for s in &gsea.summaries {
+            if s.pval.is_nan() { continue; }
+            assert!(s.pval >= eps, "p-value {:.3e} fell below eps={:.0e}", s.pval, eps);
+            if s.pval == eps {
+                clamped += 1;
+                assert!(s.log2err.is_nan(),
+                        "log2err must be NaN once the eps floor is hit, got {}", s.log2err);
+            }
+        }
+        assert!(clamped > 0, "expected at least one gene set to hit the eps floor");
     }
 
     /// Verify that classical prerank() and prerank_multilevel() produce identical ES


### PR DESCRIPTION
## Problem

`prerank_multilevel` reports the multilevel core's raw `cppMPval`. That value is a probability **conditional** on the null enrichment score sharing the sign of the observed one, so it is not a p-value on its own. `fgseaMultilevel` converts it:

```r
denomProb <- (modeFraction + 1) / (nPermSimple + 1)
result[, pval := pmin(1, cpp.res$cppMPval / denomProb)]
```

Without that division every p-value comes out roughly `1/denomProb` too small, which is about 1.9x for a sign-balanced metric, and the bias carries into the BH-adjusted FDR.

`fgseaMultilevel` also chooses between two estimators per gene set, keeping the simple permutation estimate wherever it is at least as accurate. That covers the large majority of gene sets in practice. The simple estimate is likewise normalised per sign:

```r
pval := pmin((1 + nLeEs)/(1 + nLeZero), (1 + nGeEs)/(1 + nGeZero))
```

This branch was missing entirely, so multilevel ran on every gene set and `permutation_num` had no effect on any p-value (it influenced only NES).

Every count needed for both fixes was already produced by the existing `calcGseaStatCumulativeBatch` call and used only for NES.

## Evidence

Under the null, with gene labels shuffled so nothing is truly enriched, a valid p-value is Uniform(0,1). Pooled over 5 shuffles, 326 KEGG sets, 5417-gene ranking:

| | mean p (ideal 0.500) | P(p<0.05) (ideal 0.050) | P(p<0.01) (ideal 0.010) |
|---|---|---|---|
| before | 0.2878 | 0.1215 | 0.0209 |
| after | 0.5054 | 0.0521 | 0.0080 |

A note on which fgsea to compare against: the vendored core in `src/fgsea/` tracks fgsea's development branch, and reproduces the bundled `tests/data/fgsea/` references bit-exactly under fgsea 1.39.4. The Bioconductor release 1.36.2 predates the late-2025 rewrite of the multilevel core and is not a valid reference for it. The R-layer logic this PR ports (`denomProb`, the estimator selection, `isCpGeHalf`, the `eps` clamp, BH) is identical in both, and the `fgseaSimple` p-value expression is byte-identical between them, so the fix is correct against either.

Against fgsea 1.39.4, the patched output is statistically indistinguishable from R's own run-to-run variation on two datasets, judged by comparing patched-vs-R replicate pairs against R-vs-R pairs:

| dataset | cross bias (log2) | Welch p, bias / disp / spearman | TOST |
|---|---|---|---|
| GPHK Olink, 1386 Reactome sets | +0.0011 | 0.062 / 0.68 / 0.92 | p = 1.8e-28 |
| fgsea `examplePathways`, 586 sets | +0.0093 | 0.23 / 0.079 / 0.41 | p = 1e-27 |

The current code sits 21 to 160 standard deviations outside that same envelope.

Feeding gseapy the permutation seed fgsea draws internally, and comparing against 1.36.2 (whose simple-branch code path is the byte-identical expression above), the 1302 simple-branch gene sets match to a median relative error of 3.75e-16, with 1301 of 1302 within rtol 1e-12. That pins the estimator this PR adds. Agreement with devel is distributional rather than exact because `scale_ranks` and fgsea's `prepareStats` quantise gene weights to integers slightly differently, which is independent of this change.

## Changes

* `compute_pvalue_multilevel` now returns `cppIsCpGeHalf` alongside the p-value, and its documentation states that the value is conditional and must be normalised by the caller.
* `prerank_multilevel` defers the p-value until after the permutation batch, then follows `fgseaMultilevel`: estimator selection via `simpleError` and `multError`, `denomProb` normalisation on the multilevel branch, and per-sign normalisation on the simple branch.
* Surrounding semantics brought across: `modeFraction < 10` gives NaN for `pval`, `NES` and `log2err` with a warning; `cppIsCpGeHalf == false` gives NaN `log2err` with a warning; `pval < eps` is clamped to `eps` with `log2err` set to NaN; `log2err` is recomputed from the corrected p-value via `multilevelError`.
* Two behaviour changes worth calling out explicitly. NES now uses `ES > 0` rather than `ES >= 0` and is NaN when the same-sign null mean is zero, matching `fgseaSimpleImpl`. BH now excludes NaN p-values instead of ranking them.
* Adds `qbeta` (bisection on `beta_reg`) and two small error-estimate helpers. No new dependencies, since `statrs` and `special` were already present.

One side effect: multilevel now runs on roughly 7% of gene sets instead of all of them, so this is also slightly faster, 8.8s to 7.9s on 586 sets by 12000 genes.

## Tests

Two regression tests, both verified to fail on master and pass here:

* `test_prerank_multilevel_null_calibration` checks that null p-values are approximately uniform. On master: mean 0.4028, P(p<0.05) 0.1047. Here: mean 0.5694, P(p<0.05) 0.0465.
* `test_prerank_multilevel_eps_floor` checks that no p-value falls below `eps` and that `log2err` is NaN once the floor is hit. Master reports 6.256e-6 with `eps=1e-3`.

Worth noting: the existing `test_prerank_multilevel` fixture pre-applies `abs()` to the metric. That makes every null enrichment score one-signed, drives `denomProb` to 1, and hides sign-normalisation errors, which is plausibly why this was not caught earlier. The new tests use a signed metric.

Separately, I hand-ported 7 of the 18 `test_that` blocks from fgsea's `tests/testthat/test_gsea_multilevel.R` and ran them against gseapy, with expected values generated from fgsea 1.39.4. All 9 resulting assertions pass here, against 4 of 9 on master, where master violates the `eps` floor and reports numeric `pval`, `NES` and `log2err` in cases where fgsea returns NA. These are a hand-translation rather than fgsea's suite itself, and I did not port `test_gsea_stat.R` or `test_gsea_analysis.R`.

`test_prerank_vs_fgsea` fails both before and after this change. It compares classical against multilevel NES and appears sensitive to HashMap iteration order, so it looks pre-existing and unrelated to this fix.
